### PR TITLE
RSDK-1889 Remove interaction space from scene 7

### DIFF
--- a/scenes.go
+++ b/scenes.go
@@ -284,19 +284,23 @@ func scene6() (*config, error) {
 	return cfg, err
 }
 
-// scene7: scene 4 but with a narrow interaction space
+// scene7: scene 4 but with a narrow corridor
 func scene7() (*config, error) {
 	cfg, err := scene4()
 	if err != nil {
 		return nil, err
 	}
-	ispace, err := spatialmath.NewBox(spatialmath.NewZeroPose(), r3.Vector{2000, 260, 2000}, "")
+	left_wall, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{0, 140, 0}), r3.Vector{2000, 20, 2000}, "")
 	if err != nil {
 		return nil, err
 	}
-	cfg.WorldState.InteractionSpaces = append(
-		cfg.WorldState.InteractionSpaces,
-		referenceframe.NewGeometriesInFrame(referenceframe.World, map[string]spatialmath.Geometry{"": ispace}),
+	right_wall, err := spatialmath.NewBox(spatialmath.NewPoseFromPoint(r3.Vector{0, -140, 0}), r3.Vector{2000, 20, 2000}, "")
+	if err != nil {
+		return nil, err
+	}
+	cfg.WorldState.Obstacles = append(
+		cfg.WorldState.Obstacles,
+		referenceframe.NewGeometriesInFrame(referenceframe.World, map[string]spatialmath.Geometry{"l": left_wall, "r": right_wall}),
 	)
 	return cfg, nil
 }


### PR DESCRIPTION
I removed the interaction space and instead put two walls where the sides of the I-Space were.

The walls are specified to have non-zero thickness, so that changes the Y coordinates for origin and box width, but the faces closest to the robot should be in the exact same locations as the former I-Space. I expect this to have a small impact on performance for this scene, due to collision checking against +1 geometry now (2 Obstacle boxes versus 1 I-Space box). Below is a picture of what that looks like in Ray's visualizer.

![image](https://user-images.githubusercontent.com/31750598/217980011-1247cf06-6697-4639-9a05-36845f9bbeb2.png)
