### PR TITLE
RSDK-5352: Update logger type to match rdk API.

### DIFF
--- a/evaluate.go
+++ b/evaluate.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"strings"
 
-	"github.com/edaniels/golog"
 	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/spatialmath"
@@ -15,7 +15,7 @@ import (
 
 const defaultEpsilon = 1e-2
 
-var logger golog.Logger = golog.NewLogger("motion-testing")
+var logger logging.Logger = logging.NewLogger("motion-testing")
 
 var scene *motionplan.PlanRequest
 


### PR DESCRIPTION
I'm a little unsure how this kind of change is supposed* to be handled. The RDK in [this repo's go.mod file](https://github.com/viamrobotics/motion-testing/blob/001b8d12bf0f5004c62206efb9aecf24bffe2a34/go.mod#L8) is pinned to a version back in May. And the RDK workflow [replaces it with the PR version](https://github.com/viamrobotics/rdk/blob/b630926a045df65ba6415391688233cc90303321/.github/workflows/motion-benchmarks.yml#L43).

This change should get PRs working (or at least those post-merge of rdk/RSDK-5352). But I was curious if I should be updating the motion-testing/go.mod file (maybe "pin" it to the `main` branch?) such that this can be run locally?