### PR TITLE
remove dependency on xArm module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/golang/geo v0.0.0-20230421003525-6adc56603217
 	github.com/kellydunn/golang-geo v0.7.0
-	github.com/viam-modules/viam-ufactory-xarm v0.0.0-20250602132145-704c9da34e77
 	go.viam.com/api v0.1.438
 	go.viam.com/rdk v0.77.1-0.20250528183709-63bc09bd6731
 )

--- a/go.sum
+++ b/go.sum
@@ -764,8 +764,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
@@ -862,8 +862,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/viam-modules/viam-ufactory-xarm v0.0.0-20250602132145-704c9da34e77 h1:NoHQZlZHE7VaodooRDahbwFrmL4PFj9g5QQzeg0SiL8=
-github.com/viam-modules/viam-ufactory-xarm v0.0.0-20250602132145-704c9da34e77/go.mod h1:zjhHrW/9qV1IdGogqHqjnKqvm9wWwymjctp4TYf/Rh4=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=

--- a/ur5e_kinematics.json
+++ b/ur5e_kinematics.json
@@ -1,0 +1,250 @@
+{
+    "name": "UR5e",
+    "kinematic_param_type": "SVA",
+    "links": [
+        {
+            "id": "base_link",
+            "parent": "world",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 162.5
+            },
+            "geometry": {
+                "r": 60.0,
+                "l": 260.0,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 130.0
+                }
+            }
+        },
+        {
+            "id": "shoulder_link",
+            "parent": "shoulder_pan_joint",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            }
+        },
+        {
+            "id": "upper_arm_link",
+            "parent": "shoulder_lift_joint",
+            "translation": {
+                "x": -425,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 65.0,
+                "l": 550.0,
+                "translation": {
+                    "x": -212.5,
+                    "y": -130,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": -1,
+                        "y": 0,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "forearm_link",
+            "parent": "elbow_joint",
+            "translation": {
+                "x": -392.2,
+                "y": 0,
+                "z": 0
+            },
+            "geometry": {
+                "r": 50.0,
+                "l": 490.0,
+                "translation": {
+                    "x": -196.1,
+                    "y": 0,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": -1,
+                        "y": 0,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_1_link",
+            "parent": "wrist_1_joint",
+            "translation": {
+                "x": 0,
+                "y": -133.3,
+                "z": 0
+            },
+            "geometry": {
+                "r": 40.0,
+                "l": 230.0,
+                "translation": {
+                    "x": 0,
+                    "y": -80.65,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": -1,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_2_link",
+            "parent": "wrist_2_joint",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": -99.7
+            },
+            "geometry": {
+                "r": 70.0,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": 0,
+                        "z": -1,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "ee_link",
+            "parent": "wrist_3_joint",
+            "translation": {
+                "x": 0,
+                "y": -99.6,
+                "z": 0
+            },
+            "orientation": {
+                "type": "ov_degrees",
+                "value": {
+                    "x": 0,
+                    "y": -1,
+                    "z": 0,
+                    "th": 90
+                }
+            },
+            "geometry": {
+                "r": 40.0,
+                "l": 170.0,
+                "translation": {
+                    "x": 0,
+                    "y": -49.85,
+                    "z": 0
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0,
+                        "y": -1,
+                        "z": 0,
+                        "th": 0
+                    }
+                }
+            }
+        }
+    ],
+    "joints": [
+        {
+            "id": "shoulder_pan_joint",
+            "type": "revolute",
+            "parent": "base_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "shoulder_lift_joint",
+            "type": "revolute",
+            "parent": "shoulder_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "elbow_joint",
+            "type": "revolute",
+            "parent": "upper_arm_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 180,
+            "min": -180
+        },
+        {
+            "id": "wrist_1_joint",
+            "type": "revolute",
+            "parent": "forearm_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_2_joint",
+            "type": "revolute",
+            "parent": "wrist_1_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 360,
+            "min": -360
+        },
+        {
+            "id": "wrist_3_joint",
+            "type": "revolute",
+            "parent": "wrist_2_link",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 360,
+            "min": -360
+        }
+    ]
+}

--- a/xarm6_kinematics.json
+++ b/xarm6_kinematics.json
@@ -1,0 +1,224 @@
+{
+    "name": "xArm6",
+    "links": [
+        {
+            "id": "base",
+            "parent": "world",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            }
+        },
+        {
+            "id": "base_top",
+            "parent": "waist",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 267
+            },
+            "geometry": {
+                "r": 50,
+                "l": 320,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 160
+                }
+            }
+        },
+        {
+            "id": "upper_arm",
+            "parent": "shoulder",
+            "translation": {
+                "x": 53.5,
+                "y": 0,
+                "z": 284.5
+            },
+            "geometry": {
+                "r": 70,
+                "l": 370,
+                "translation": {
+                    "x": 0,
+                    "y": 40,
+                    "z": 135
+                },
+                "orientation" : {
+                    "type" : "ov_degrees",
+                    "value" : {
+                        "x" : 0,
+                        "y" : -0.333,
+                        "z" :  0.666
+                    }
+                }
+            }
+        },
+        {
+            "id": "upper_forearm",
+            "parent": "elbow",
+            "translation": {
+                "x": 77.5,
+                "y": 0,
+                "z": -172.5
+            },
+            "geometry": {
+                "x": 80,
+                "y": 180,
+                "z": 250,
+                "translation": {
+                    "x": 49.49,
+                    "y": 20,
+                    "z": -49.49
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0.707106,
+                        "y": 0,
+                        "z": -0.707106,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "lower_forearm",
+            "parent": "forearm_rot",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": -170
+            },
+            "geometry": {
+                "r": 45,
+                "l": 285,
+                "translation": {
+                    "x": 0,
+                    "y": -27.5,
+                    "z": -104.8
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "th": -90,
+                        "x": 0,
+                        "y": 0.2537568,
+                        "z": 0.9672615
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_link",
+            "parent": "wrist",
+            "translation": {
+                "x": 76,
+                "y": 0,
+                "z": -97
+            },
+            "geometry": {
+                "x": 150,
+                "y": 100,
+                "z": 125,
+                "translation": {
+                    "x": 35,
+                    "y": 0,
+                    "z": -32.5
+                }
+            }
+        },
+        {
+            "id": "gripper_mount",
+            "parent": "gripper_rot",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "orientation": {
+                "type": "ov_degrees",
+                "value": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -1,
+                    "th": 0
+                }
+            }
+        }
+    ],
+    "joints": [
+        {
+            "id": "waist",
+            "type": "revolute",
+            "parent": "base",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 359,
+            "min": -359
+        },
+        {
+            "id": "shoulder",
+            "type": "revolute",
+            "parent": "base_top",
+            "axis": {
+                "x": 0,
+                "y": 1,
+                "z": 0
+            },
+            "max": 120,
+            "min": -118
+        },
+        {
+            "id": "elbow",
+            "type": "revolute",
+            "parent": "upper_arm",
+            "axis": {
+                "x": 0,
+                "y": 1,
+                "z": 0
+            },
+            "max": 10,
+            "min": -225
+        },
+        {
+            "id": "forearm_rot",
+            "type": "revolute",
+            "parent": "upper_forearm",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 359,
+            "min": -359
+        },
+        {
+            "id": "wrist",
+            "type": "revolute",
+            "parent": "lower_forearm",
+            "axis": {
+                "x": 0,
+                "y": 1,
+                "z": 0
+            },
+            "max": 179,
+            "min": -97
+        },
+        {
+            "id": "gripper_rot",
+            "type": "revolute",
+            "parent": "wrist_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 359,
+            "min": -359
+        }
+    ]
+}

--- a/xarm7_kinematics.json
+++ b/xarm7_kinematics.json
@@ -1,0 +1,257 @@
+{
+    "name": "xArm7",
+    "links": [
+        {
+            "id": "base",
+            "parent": "world",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            }
+        },
+        {
+            "id": "base_top",
+            "parent": "waist",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 267
+            },
+            "geometry": {
+                "r": 50,
+                "l": 320,
+                "translation": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 160
+                }
+            }
+        },
+        {
+            "id": "base_arm_link",
+            "parent": "shoulder",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 200
+            },
+            "geometry": {
+                "x": 110,
+                "y": 190,
+                "z": 220,
+                "translation": {
+                    "x": 0,
+                    "y": 30,
+                    "z": 100
+                }
+            }
+        },
+        {
+            "id": "upper_arm",
+            "parent": "upper_arm_rot",
+            "translation": {
+                "x": 52.5,
+                "y": 0,
+                "z": 93
+            },
+            "geometry": {
+                "x": 100,
+                "y": 130,
+                "z": 180,
+                "translation": {
+                    "x": 32.88,
+                    "y": -10,
+                    "z": 32.88
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0.707106,
+                        "y": 0,
+                        "z": 0.707106,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "upper_forearm",
+            "parent": "elbow",
+            "translation": {
+                "x": 77.5,
+                "y": 0,
+                "z": -172.5
+            },
+            "geometry": {
+                "x": 100,
+                "y": 150,
+                "z": 250,
+                "translation": {
+                    "x": 60.98,
+                    "y": -37.5,
+                    "z": -60.98
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "x": 0.707106,
+                        "y": 0,
+                        "z": -0.707106,
+                        "th": 0
+                    }
+                }
+            }
+        },
+        {
+            "id": "lower_forearm",
+            "parent": "forearm_rot",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": -170
+            },
+            "geometry": {
+                "r": 45,
+                "l": 285,
+                "translation": {
+                    "x": 0,
+                    "y": -27.5,
+                    "z": -104.8
+                },
+                "orientation": {
+                    "type": "ov_degrees",
+                    "value": {
+                        "th": -90,
+                        "x": 0,
+                        "y": 0.2537568,
+                        "z": 0.9672615
+                    }
+                }
+            }
+        },
+        {
+            "id": "wrist_link",
+            "parent": "wrist",
+            "translation": {
+                "x": 76,
+                "y": 0,
+                "z": -97
+            },
+            "geometry": {
+                "x": 150,
+                "y": 100,
+                "z": 135,
+                "translation": {
+                    "x": 75,
+                    "y": 0,
+                    "z": -67.5
+                }
+            }
+        },
+        {
+            "id": "gripper_mount",
+            "parent": "gripper_rot",
+            "translation": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "orientation": {
+                "type": "ov_degrees",
+                "value": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -1,
+                    "th": 0
+                }
+            }
+        }
+    ],
+    "joints": [
+        {
+            "id": "waist",
+            "type": "revolute",
+            "parent": "base",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 359,
+            "min": -359
+        },
+        {
+            "id": "shoulder",
+            "type": "revolute",
+            "parent": "base_top",
+            "axis": {
+                "x": 0,
+                "y": 1,
+                "z": 0
+            },
+            "max": 120,
+            "min": -118
+        },
+        {
+            "id": "upper_arm_rot",
+            "type": "revolute",
+            "parent": "base_arm_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+            },
+            "max": 359,
+            "min": -359
+        },
+        {
+            "id": "elbow",
+            "type": "revolute",
+            "parent": "upper_arm",
+            "axis": {
+                "x": 0,
+                "y": -1,
+                "z": 0
+            },
+            "max": 225,
+            "min": -11
+        },
+        {
+            "id": "forearm_rot",
+            "type": "revolute",
+            "parent": "upper_forearm",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 359,
+            "min": -359
+        },
+        {
+            "id": "wrist",
+            "type": "revolute",
+            "parent": "lower_forearm",
+            "axis": {
+                "x": 0,
+                "y": 1,
+                "z": 0
+            },
+            "max": 179,
+            "min": -97
+        },
+        {
+            "id": "gripper_rot",
+            "type": "revolute",
+            "parent": "wrist_link",
+            "axis": {
+                "x": 0,
+                "y": 0,
+                "z": -1
+            },
+            "max": 359,
+            "min": -359
+        }
+    ]
+}


### PR DESCRIPTION
This secures us against breaking changes to component interfaces by relying directly on the kinematics files (which are very unlikely to change)