### PR TITLE
Set up .claude directory with permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Read", "Edit", "Write"],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ results/
 .artifact/cache
 .DS_Store
 *~
+
+# Claude Code
+.claude/worktrees
+.claude/settings.local.json


### PR DESCRIPTION
## What

Adds baseline Claude Code configuration to this repository:

- **`.claude/settings.json`** — grants `Read`, `Edit`, and `Write` tool permissions so Claude Code can assist without repeated prompts.
- **`.gitignore`** — excludes `.claude/worktrees` and `.claude/settings.local.json` from version control.

Existing settings and `.gitignore` entries are preserved; only missing pieces are added.

More permissions which are relevant for this repo can be added to `.claude/settings.json` afterwards. This is only the initialization and the repo owners should be free to iterate on it.